### PR TITLE
UnicodeDecodeError on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
+import io
 from setuptools import setup
 
 
@@ -8,7 +9,7 @@ setup(
     name='igo-python',
     version='0.9.3',
     description='Python port of Igo Japanese morphological analyzer',
-    long_description=open('README', encoding='utf-8').read() + "\n\n" + open('CHANGES', encoding='utf-8').read(),
+    long_description=io.open('README', encoding='utf-8').read() + "\n\n" + io.open('CHANGES', encoding='utf-8').read(),
     author='Hideaki Takahashi',
     author_email='mymelo@gmail.com',
     url='https://github.com/hideaki-t/igo-python/',


### PR DESCRIPTION
Hello.

When I try to build igo-python on Python 3.3.5 for Windows, UnicodeDecodeError is raised.

```
>python setup.py build
Traceback (most recent call last):
  File "setup.py", line 11, in <module>
    long_description=open('README').read() + "\n\n" + open('CHANGES').read(),
UnicodeDecodeError: 'cp932' codec can't decode byte 0x81 in position 516: illegal multibyte sequence
```
